### PR TITLE
JSHint should recurse more + pass all tests

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -22,6 +22,14 @@ module.exports = function (grunt) {
     dist: 'dist'
   };
 
+  var userJS = [
+        'Gruntfile.js',
+        '<%= config.app %>/scripts/{,**/}*.js',
+        '!<%= config.app %>/scripts/**/mediaelement/*',
+        '!<%= config.app %>/scripts/vendor/**',
+        'test/spec/{,*/}*.js'
+      ];
+
   // Define the configuration for all the tasks
   grunt.initConfig({
 
@@ -35,25 +43,25 @@ module.exports = function (grunt) {
         tasks: ['wiredep']
       },
       js: {
-        files: ['<%= config.app %>/scripts/{,*/}*.js'],
+        files: userJS,
         tasks: ['jshint'],
         options: {
           livereload: true
         }
       },
       jstest: {
-        files: ['test/spec/{,*/}*.js'],
+        files: ['test/spec/{,**/}*.js'],
         tasks: ['test:watch']
       },
       gruntfile: {
         files: ['Gruntfile.js']
       },
       sass: {
-        files: ['<%= config.app %>/styles/{,*/}*.{scss,sass}'],
+        files: ['<%= config.app %>/styles/{,**/}*.{scss,sass}'],
         tasks: ['sass:server', 'autoprefixer']
       },
       styles: {
-        files: ['<%= config.app %>/styles/{,*/}*.css'],
+        files: ['<%= config.app %>/styles/{,**/}*.css'],
         tasks: ['newer:copy:styles', 'autoprefixer']
       },
       livereload: {
@@ -61,9 +69,9 @@ module.exports = function (grunt) {
           livereload: '<%= connect.options.livereload %>'
         },
         files: [
-          '<%= config.app %>/{,*/}*.html',
-          '.tmp/styles/{,*/}*.css',
-          '<%= config.app %>/images/{,*/}*'
+          '<%= config.app %>/{,**/}*.html',
+          '.tmp/styles/{,**/}*.css',
+          '<%= config.app %>/images/{,**/}*'
         ]
       }
     },
@@ -131,12 +139,7 @@ module.exports = function (grunt) {
         jshintrc: '.jshintrc',
         reporter: require('jshint-stylish')
       },
-      all: [
-        'Gruntfile.js',
-        '<%= config.app %>/scripts/{,*/}*.js',
-        '!<%= config.app %>/scripts/vendor/*',
-        'test/spec/{,*/}*.js'
-      ]
+      all: userJS 
     },
 
     // Mocha testing framework configuration options

--- a/app/scripts/component/npButton/npButton.js
+++ b/app/scripts/component/npButton/npButton.js
@@ -51,7 +51,7 @@ angular
 				} else {
 					document.location = this.link;
 				}
-			}
+			};
 		}
 	)
 

--- a/app/scripts/component/npMenu/npMenu.js
+++ b/app/scripts/component/npMenu/npMenu.js
@@ -62,7 +62,7 @@ angular
 				for ( var itemIdx in this.items )
 				{
 					var item = this.items[ itemIdx ];
-					if ( item === "pages" )
+					if ( item === 'pages' )
 					{
 
 						// have pages been indexed?

--- a/app/scripts/component/npVideo/npVideo.js
+++ b/app/scripts/component/npVideo/npVideo.js
@@ -55,7 +55,7 @@ angular
 				{
 					var type = types[typeIdx];
 					$log.debug( 'npVideo::data:types:type', typeIdx, type );
-					sources += '<source type="video/' + type + '" src="' + this.baseURL + '.' + type + '" />'
+					sources += '<source type="video/' + type + '" src="' + this.baseURL + '.' + type + '" />';
 				}
 				$scope.sources = sources;
 			}


### PR DESCRIPTION
... and should ignore mediaelement stuff.

The current Gruntfile did not recurse far enough for some of the patterns we're using, so made it recurse more. The current codebase should also pass all jshint tests, which is was not.
